### PR TITLE
Remove magic mapping type to get IndexPatternColumn

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/cardinality.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/cardinality.tsx
@@ -51,7 +51,7 @@ export const cardinalityOperation: OperationDefinition<CardinalityIndexPatternCo
   },
   buildColumn({ suggestedPriority, field, previousColumn }) {
     let params;
-    if (previousColumn?.dataType === 'number' && 'params' in previousColumn) {
+    if (previousColumn?.dataType === 'number' && previousColumn?.operationType === 'cardinality') {
       params = previousColumn.params;
     }
     return {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/count.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/count.tsx
@@ -41,7 +41,7 @@ export const countOperation: OperationDefinition<CountIndexPatternColumn> = {
   },
   buildColumn({ suggestedPriority, field, previousColumn }) {
     let params;
-    if (previousColumn?.dataType === 'number' && 'params' in previousColumn) {
+    if (previousColumn?.dataType === 'number' && previousColumn.operationType === 'count') {
       params = previousColumn.params;
     }
     return {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/filters/filters.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/filters/filters.tsx
@@ -125,11 +125,7 @@ export const filtersOperation: OperationDefinition<FiltersIndexPatternColumn> = 
           },
         ],
       };
-    } else if (
-      previousColumn?.operationType === 'filters' &&
-      'params' in previousColumn &&
-      previousColumn.params?.filters
-    ) {
+    } else if (previousColumn?.operationType === 'filters' && previousColumn.params?.filters) {
       params = previousColumn.params;
     }
 

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/metrics.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/metrics.tsx
@@ -52,7 +52,7 @@ function buildMetricOperation<T extends MetricColumn<string>>({
     },
     buildColumn: ({ suggestedPriority, field, previousColumn }) => {
       let params;
-      if (previousColumn?.dataType === 'number' && 'params' in previousColumn) {
+      if (previousColumn?.dataType === 'number' && previousColumn.operationType === type) {
         params = previousColumn.params;
       }
       return {


### PR DESCRIPTION
This PR removes the mapping type infering all possible columns for the definition array
```ts
export type IndexPatternColumn = ColumnFromOperationDefinition<	
  typeof internalOperationDefinitions[number]	
>;
```

by an explicit list:

```
export type IndexPatternColumn =
  | FiltersIndexPatternColumn
  | TermsIndexPatternColumn
  | DateHistogramIndexPatternColumn
  | MinIndexPatternColumn
  | MaxIndexPatternColumn
  | AvgIndexPatternColumn
  | CardinalityIndexPatternColumn
  | SumIndexPatternColumn
  | CountIndexPatternColumn;
```

This has the advantage of decoupling the column type from the definition type, which means we can use `IndexPatternColumn` in the definition interfaces.

The downside is definitions and columns can diverge (if a definition is added to the array, but the corresponding column type is not added to the union type). However this is unlikely to happen in practice, that's why I think it's fine.

Also, this PR removes the unnecessary `FieldBasedOperationDefinition` intermediary type