### PR TITLE
[Lens] "Add field to workspace" button design tweaks

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/field_item.scss
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/field_item.scss
@@ -42,7 +42,6 @@
   max-width: 300px;
 }
 
-.lnsFieldItem__buttonGroup {
-  // Enforce lowercase for buttons or else some browsers inherit all caps from flyout title
+.lnsFieldItem__fieldPanelTitle {
   text-transform: none;
 }


### PR DESCRIPTION
Hey, @mbondyra. Per your request, here is a quick design PR for your `dnd_to_workspace` branch. It changes up a few things, including:

- Added `field.displayName` as a new top-level heading for all field popovers. Doing so adds improved hierarchy and header consistency between all field popovers, while also affording us the space needed to move up the "Add field to workspace" button (as described below).
- Moved "Add field to workspace" button to the right side of the updated header area. Doing so ensures that the button will be focused on first tab-press after opening the popover, rather than having to tab past other controls (i.e. the popovers containing a button group).
- Changed the "Add field to workspace" button to an `EuiIconButton` component to reduce the footprint and attention it demanded previously.
- Moved the previous titles (and button groups) for top values, time distribution, and distribution into the main content area of the popovers, below the updated header area.
- Updated the footer to be left aligned to match alignment with the rest of the popover contents. Also applied the `subdued` text color to make it demand less attention.

Let me know if these changes work for you, or if there's anything you'd suggest doing differently. Otherwise, some screenshots can be seen below. Thanks!

### Popover standard
![image](https://user-images.githubusercontent.com/3884767/102543648-99c95700-4081-11eb-877f-38addf604161.png)

### Popover with button group
![image](https://user-images.githubusercontent.com/3884767/102543738-bd8c9d00-4081-11eb-87c7-5682bc1d120e.png)

### Popover with empty message
![image](https://user-images.githubusercontent.com/3884767/102543549-77cfd480-4081-11eb-8d8c-76dae2e3885a.png)

### Popover with no content
![image](https://user-images.githubusercontent.com/3884767/102543439-4f47da80-4081-11eb-9631-c812feacf49b.png)

### Popover with no suggestion to add to workspace
![image](https://user-images.githubusercontent.com/3884767/102543790-d006d680-4081-11eb-97bc-e06b77d26a34.png)
