### PR TITLE
Threshold tests

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/config_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/config_panel.tsx
@@ -178,7 +178,7 @@ export function LayerPanels(
               ) === 'clear'
             }
             onEmptyDimensionAdd={(columnId, { groupId }) => {
-              addMaybeDefaultThreshold({
+              addInitialValueIfAvailable({
                 ...props,
                 visualization,
                 activeDatasourceId: activeDatasourceId!,
@@ -255,7 +255,7 @@ export function LayerPanels(
                 }),
             })
           );
-          addMaybeDefaultThreshold({
+          addInitialValueIfAvailable({
             ...props,
             activeDatasourceId: activeDatasourceId!,
             visualization,
@@ -270,7 +270,7 @@ export function LayerPanels(
   );
 }
 
-function addMaybeDefaultThreshold({
+function addInitialValueIfAvailable({
   activeVisualization,
   visualization,
   framePublicAPI,
@@ -298,6 +298,7 @@ function addMaybeDefaultThreshold({
   const layerInfo = activeVisualization
     .getSupportedLayers(visualization.state, framePublicAPI)
     .find(({ type }) => type === layerType);
+
   if (layerInfo?.initialDimensions && datasourceMap[activeDatasourceId]?.initializeDimension) {
     const info = groupId
       ? layerInfo.initialDimensions.find(({ groupId: id }) => id === groupId)

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.test.tsx
@@ -921,4 +921,33 @@ describe('LayerPanel', () => {
       expect(updateVisualization).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('add a new dimension', () => {
+    it('should call onEmptyDimensionAdd callback on new dimension creation', async () => {
+      mockVisualization.getConfiguration.mockReturnValue({
+        groups: [
+          {
+            groupLabel: 'A',
+            groupId: 'a',
+            accessors: [],
+            filterOperations: () => true,
+            supportsMoreColumns: true,
+            dataTestSubj: 'lnsGroup',
+          },
+        ],
+      });
+      const props = getDefaultProps();
+      const { instance } = await mountWithProvider(<LayerPanel {...props} />);
+
+      act(() => {
+        instance.find('[data-test-subj="lns-empty-dimension"]').first().simulate('click');
+      });
+      instance.update();
+
+      expect(props.onEmptyDimensionAdd).toHaveBeenCalledWith(
+        'newid',
+        expect.objectContaining({ groupId: 'a' })
+      );
+    });
+  });
 });

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_settings.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_settings.test.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  createMockFramePublicAPI,
+  createMockVisualization,
+  mountWithProvider,
+} from '../../../mocks';
+import { Visualization } from '../../../types';
+import { LayerSettings } from './layer_settings';
+
+describe('LayerSettings', () => {
+  let mockVisualization: jest.Mocked<Visualization>;
+  const frame = createMockFramePublicAPI();
+
+  function getDefaultProps() {
+    return {
+      activeVisualization: mockVisualization,
+      layerConfigProps: {
+        layerId: 'myLayer',
+        state: {},
+        frame,
+        dateRange: { fromDate: 'now-7d', toDate: 'now' },
+        activeData: frame.activeData,
+        setState: jest.fn(),
+      },
+    };
+  }
+
+  beforeEach(() => {
+    mockVisualization = {
+      ...createMockVisualization(),
+      id: 'testVis',
+      visualizationTypes: [
+        {
+          icon: 'empty',
+          id: 'testVis',
+          label: 'TEST1',
+          groupLabel: 'testVisGroup',
+        },
+      ],
+    };
+  });
+
+  it('should render nothing with no custom renderer nor description', async () => {
+    // @ts-expect-error
+    mockVisualization.getDescription.mockReturnValue(undefined);
+    const { instance } = await mountWithProvider(<LayerSettings {...getDefaultProps()} />);
+    expect(instance.html()).toBe(null);
+  });
+
+  it('should render a static header if visualization has only a description value', async () => {
+    mockVisualization.getDescription.mockReturnValue({
+      icon: 'myIcon',
+      label: 'myVisualizationType',
+    });
+    const { instance } = await mountWithProvider(<LayerSettings {...getDefaultProps()} />);
+    expect(instance.find('StaticHeader').first().prop('label')).toBe('myVisualizationType');
+  });
+
+  it('should call the custom renderer if available', async () => {
+    mockVisualization.renderLayerHeader = jest.fn();
+    await mountWithProvider(<LayerSettings {...getDefaultProps()} />);
+    expect(mockVisualization.renderLayerHeader).toHaveBeenCalled();
+  });
+});

--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_editor.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_editor.tsx
@@ -678,7 +678,11 @@ export function DimensionEditor(props: DimensionEditorProps) {
   return (
     <div id={columnId}>
       {hasTabs ? (
-        <EuiTabs size="s" className="lnsIndexPatternDimensionEditor__header">
+        <EuiTabs
+          size="s"
+          className="lnsIndexPatternDimensionEditor__header"
+          data-test-subj="lens-dimensionTabs"
+        >
           {supportStaticValue ? (
             <EuiTab
               isSelected={

--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_panel.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_panel.test.tsx
@@ -2227,6 +2227,36 @@ describe('IndexPatternDimensionEditorPanel', () => {
     );
   });
 
+  it('should not show tabs when formula and static_value operations are not available', () => {
+    const stateWithInvalidCol: IndexPatternPrivateState = getStateWithColumns({
+      col1: {
+        label: 'Average of memory',
+        dataType: 'number',
+        isBucketed: false,
+        // Private
+        operationType: 'average',
+        sourceField: 'memory',
+        params: {
+          format: { id: 'bytes', params: { decimals: 2 } },
+        },
+      },
+    });
+
+    const props = {
+      ...defaultProps,
+      filterOperations: jest.fn((op) => {
+        // the formula operation will fall into this metadata category
+        return !(op.dataType === 'number' && op.scale === 'ratio');
+      }),
+    };
+
+    wrapper = mount(
+      <IndexPatternDimensionEditorComponent {...props} state={stateWithInvalidCol} />
+    );
+
+    expect(wrapper.find('[data-test-subj="lens-dimensionTabs"]').exists()).toBeFalsy();
+  });
+
   it('should show the formula tab when supported', () => {
     const stateWithFormulaColumn: IndexPatternPrivateState = getStateWithColumns({
       col1: {
@@ -2292,33 +2322,34 @@ describe('IndexPatternDimensionEditorPanel', () => {
     ).toBeTruthy();
   });
 
-  it('should not show tabs when formula and static_value operations are not available', () => {
-    const stateWithInvalidCol: IndexPatternPrivateState = getStateWithColumns({
-      col1: {
-        label: 'Average of memory',
-        dataType: 'number',
-        isBucketed: false,
-        // Private
-        operationType: 'average',
-        sourceField: 'memory',
-        params: {
-          format: { id: 'bytes', params: { decimals: 2 } },
-        },
-      },
-    });
-
-    const props = {
-      ...defaultProps,
-      filterOperations: jest.fn((op) => {
-        // the formula operation will fall into this metadata category
-        return !(op.dataType === 'number' && op.scale === 'ratio');
-      }),
-    };
+  it('should select the quick function tab by default', () => {
+    const stateWithNoColumn: IndexPatternPrivateState = getStateWithColumns({});
 
     wrapper = mount(
-      <IndexPatternDimensionEditorComponent {...props} state={stateWithInvalidCol} />
+      <IndexPatternDimensionEditorComponent {...defaultProps} state={stateWithNoColumn} />
     );
 
-    expect(wrapper.find('[data-test-subj="lens-dimensionTabs"]').exists()).toBeFalsy();
+    expect(
+      wrapper
+        .find('[data-test-subj="lens-dimensionTabs-quickFunctions"]')
+        .first()
+        .prop('isSelected')
+    ).toBeTruthy();
+  });
+
+  it('should select the static value tab when supported by default', () => {
+    const stateWithNoColumn: IndexPatternPrivateState = getStateWithColumns({});
+
+    wrapper = mount(
+      <IndexPatternDimensionEditorComponent
+        {...defaultProps}
+        supportStaticValue
+        state={stateWithNoColumn}
+      />
+    );
+
+    expect(
+      wrapper.find('[data-test-subj="lens-dimensionTabs-static_value"]').first().prop('isSelected')
+    ).toBeTruthy();
   });
 });

--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.test.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.test.ts
@@ -1623,4 +1623,87 @@ describe('IndexPattern Data Source', () => {
       expect(indexPatternDatasource.isTimeBased(state)).toEqual(false);
     });
   });
+
+  describe('#initializeDimension', () => {
+    it('should return the same state if no static value is passed', () => {
+      const state = enrichBaseState({
+        currentIndexPatternId: '1',
+        layers: {
+          first: {
+            indexPatternId: '1',
+            columnOrder: ['metric'],
+            columns: {
+              metric: {
+                label: 'Count of records',
+                dataType: 'number',
+                isBucketed: false,
+                sourceField: 'Records',
+                operationType: 'count',
+              },
+            },
+          },
+        },
+      });
+      expect(
+        indexPatternDatasource.initializeDimension!(state, 'first', {
+          columnId: 'newStatic',
+          label: 'MyNewColumn',
+          groupId: 'a',
+          dataType: 'number',
+        })
+      ).toBe(state);
+    });
+
+    it('should add a new static value column if a static value is passed', () => {
+      const state = enrichBaseState({
+        currentIndexPatternId: '1',
+        layers: {
+          first: {
+            indexPatternId: '1',
+            columnOrder: ['metric'],
+            columns: {
+              metric: {
+                label: 'Count of records',
+                dataType: 'number',
+                isBucketed: false,
+                sourceField: 'Records',
+                operationType: 'count',
+              },
+            },
+          },
+        },
+      });
+      expect(
+        indexPatternDatasource.initializeDimension!(state, 'first', {
+          columnId: 'newStatic',
+          label: 'MyNewColumn',
+          groupId: 'a',
+          dataType: 'number',
+          staticValue: 0, // use a falsy value to check also this corner case
+        })
+      ).toEqual({
+        ...state,
+        layers: {
+          ...state.layers,
+          first: {
+            ...state.layers.first,
+            incompleteColumns: {},
+            columnOrder: ['metric', 'newStatic'],
+            columns: {
+              ...state.layers.first.columns,
+              newStatic: {
+                dataType: 'number',
+                isBucketed: false,
+                label: 'Static Value: 0',
+                operationType: 'static_value',
+                params: { value: 0 },
+                references: [],
+                scale: 'ratio',
+              },
+            },
+          },
+        },
+      });
+    });
+  });
 });

--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.tsx
@@ -196,6 +196,9 @@ export function getIndexPatternDatasource({
 
     initializeDimension(state, layerId, { columnId, groupId, label, dataType, staticValue }) {
       const indexPattern = state.indexPatterns[state.layers[layerId]?.indexPatternId];
+      if (staticValue == null) {
+        return state;
+      }
       return mergeLayer({
         state,
         layerId,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/helpers.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/helpers.tsx
@@ -7,7 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { IndexPatternColumn, operationDefinitionMap } from '.';
-import { FieldBasedIndexPatternColumn } from './column_types';
+import { FieldBasedIndexPatternColumn, ReferenceBasedIndexPatternColumn } from './column_types';
 import { IndexPattern } from '../../types';
 
 export function getInvalidFieldMessage(
@@ -81,8 +81,7 @@ export function isValidNumber(
   const inputValueAsNumber = Number(inputValue);
   return (
     inputValue !== '' &&
-    inputValue !== null &&
-    inputValue !== undefined &&
+    inputValue != null &&
     !Number.isNaN(inputValueAsNumber) &&
     Number.isFinite(inputValueAsNumber) &&
     (!integer || Number.isInteger(inputValueAsNumber)) &&
@@ -91,7 +90,9 @@ export function isValidNumber(
   );
 }
 
-export function getFormatFromPreviousColumn(previousColumn: IndexPatternColumn | undefined) {
+export function getFormatFromPreviousColumn(
+  previousColumn: IndexPatternColumn | ReferenceBasedIndexPatternColumn | undefined
+) {
   return previousColumn?.dataType === 'number' &&
     previousColumn.params &&
     'format' in previousColumn.params &&

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/static_value.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/static_value.test.tsx
@@ -1,0 +1,402 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import { IUiSettingsClient, SavedObjectsClientContract, HttpSetup } from 'kibana/public';
+import { IStorageWrapper } from 'src/plugins/kibana_utils/public';
+import { dataPluginMock } from '../../../../../../../src/plugins/data/public/mocks';
+import { createMockedIndexPattern } from '../../mocks';
+import { staticValueOperation } from './index';
+import { IndexPattern, IndexPatternLayer } from '../../types';
+import { StaticValueIndexPatternColumn } from './static_value';
+import { EuiFieldNumber } from '@elastic/eui';
+import { act } from 'react-dom/test-utils';
+
+jest.mock('lodash', () => {
+  const original = jest.requireActual('lodash');
+
+  return {
+    ...original,
+    debounce: (fn: unknown) => fn,
+  };
+});
+
+const uiSettingsMock = {} as IUiSettingsClient;
+
+const defaultProps = {
+  storage: {} as IStorageWrapper,
+  uiSettings: uiSettingsMock,
+  savedObjectsClient: {} as SavedObjectsClientContract,
+  dateRange: { fromDate: 'now-1d', toDate: 'now' },
+  data: dataPluginMock.createStartContract(),
+  http: {} as HttpSetup,
+  indexPattern: {
+    ...createMockedIndexPattern(),
+    hasRestrictions: false,
+  } as IndexPattern,
+  operationDefinitionMap: {},
+  isFullscreen: false,
+  toggleFullscreen: jest.fn(),
+  setIsCloseable: jest.fn(),
+  layerId: '1',
+};
+
+describe('static_value', () => {
+  let layer: IndexPatternLayer;
+
+  beforeEach(() => {
+    layer = {
+      indexPatternId: '1',
+      columnOrder: ['col1', 'col2'],
+      columns: {
+        col1: {
+          label: 'Top value of category',
+          dataType: 'string',
+          isBucketed: true,
+          operationType: 'terms',
+          params: {
+            orderBy: { type: 'alphabetical' },
+            size: 3,
+            orderDirection: 'asc',
+          },
+          sourceField: 'category',
+        },
+        col2: {
+          label: 'Static value: 23',
+          dataType: 'number',
+          isBucketed: false,
+          operationType: 'static_value',
+          references: [],
+          params: {
+            value: '23',
+          },
+        },
+      },
+    };
+  });
+
+  function getLayerWithStaticValue(newValue: string): IndexPatternLayer {
+    return {
+      ...layer,
+      columns: {
+        ...layer.columns,
+        col2: {
+          ...layer.columns.col2,
+          label: `Static value: ${newValue}`,
+          params: {
+            value: newValue,
+          },
+        } as StaticValueIndexPatternColumn,
+      },
+    };
+  }
+
+  describe('getDefaultLabel', () => {
+    it('should return the label for the given value', () => {
+      expect(
+        staticValueOperation.getDefaultLabel(
+          {
+            label: 'Static value: 23',
+            dataType: 'number',
+            isBucketed: false,
+            operationType: 'static_value',
+            references: [],
+            params: {
+              value: '23',
+            },
+          },
+          createMockedIndexPattern(),
+          layer.columns
+        )
+      ).toBe('Static value: 23');
+    });
+
+    it('should return the default label for non valid value', () => {
+      expect(
+        staticValueOperation.getDefaultLabel(
+          {
+            label: 'Static value',
+            dataType: 'number',
+            isBucketed: false,
+            operationType: 'static_value',
+            references: [],
+            params: {
+              value: '',
+            },
+          },
+          createMockedIndexPattern(),
+          layer.columns
+        )
+      ).toBe('Static value');
+    });
+  });
+
+  describe('getErrorMessage', () => {
+    it('should return no error for valid values', () => {
+      expect(
+        staticValueOperation.getErrorMessage!(
+          getLayerWithStaticValue('23'),
+          'col2',
+          createMockedIndexPattern()
+        )
+      ).toBeUndefined();
+      // test for potential falsy value
+      expect(
+        staticValueOperation.getErrorMessage!(
+          getLayerWithStaticValue('0'),
+          'col2',
+          createMockedIndexPattern()
+        )
+      ).toBeUndefined();
+    });
+
+    it('should return error for invalid values', () => {
+      for (const value of ['NaN', 'Infinity', 'string']) {
+        expect(
+          staticValueOperation.getErrorMessage!(
+            getLayerWithStaticValue(value),
+            'col2',
+            createMockedIndexPattern()
+          )
+        ).toEqual(expect.arrayContaining([expect.stringMatching('is not a valid number')]));
+      }
+    });
+  });
+
+  describe('toExpression', () => {
+    it('should return a mathColumn operation with valid value', () => {
+      for (const value of ['23', '0', '-1']) {
+        expect(
+          staticValueOperation.toExpression(
+            getLayerWithStaticValue(value),
+            'col2',
+            createMockedIndexPattern()
+          )
+        ).toEqual([
+          {
+            type: 'function',
+            function: 'mathColumn',
+            arguments: {
+              id: ['col2'],
+              name: [`Static value: ${value}`],
+              expression: [value],
+            },
+          },
+        ]);
+      }
+    });
+
+    it('should fallback to mapColumn for invalid value', () => {
+      for (const value of ['NaN', '', 'Infinity']) {
+        expect(
+          staticValueOperation.toExpression(
+            getLayerWithStaticValue(value),
+            'col2',
+            createMockedIndexPattern()
+          )
+        ).toEqual([
+          {
+            type: 'function',
+            function: 'mapColumn',
+            arguments: {
+              id: ['col2'],
+              name: [`Static value`],
+              expression: ['100'],
+            },
+          },
+        ]);
+      }
+    });
+  });
+
+  describe('buildColumn', () => {
+    it('should set default static value', () => {
+      expect(
+        staticValueOperation.buildColumn({
+          indexPattern: createMockedIndexPattern(),
+          layer: { columns: {}, columnOrder: [], indexPatternId: '' },
+        })
+      ).toEqual({
+        label: 'Static value',
+        dataType: 'number',
+        operationType: 'static_value',
+        isBucketed: false,
+        scale: 'ratio',
+        params: { value: '100' },
+        references: [],
+      });
+    });
+
+    it('should merge a previousColumn', () => {
+      expect(
+        staticValueOperation.buildColumn({
+          indexPattern: createMockedIndexPattern(),
+          layer: { columns: {}, columnOrder: [], indexPatternId: '' },
+          previousColumn: {
+            label: 'Static value',
+            dataType: 'number',
+            operationType: 'static_value',
+            isBucketed: false,
+            scale: 'ratio',
+            params: { value: '23' },
+            references: [],
+          },
+        })
+      ).toEqual({
+        label: 'Static value: 23',
+        dataType: 'number',
+        operationType: 'static_value',
+        isBucketed: false,
+        scale: 'ratio',
+        params: { value: '23' },
+        references: [],
+      });
+    });
+
+    it('should create a static_value from passed arguments', () => {
+      expect(
+        staticValueOperation.buildColumn(
+          {
+            indexPattern: createMockedIndexPattern(),
+            layer: { columns: {}, columnOrder: [], indexPatternId: '' },
+          },
+          { value: '23' }
+        )
+      ).toEqual({
+        label: 'Static value: 23',
+        dataType: 'number',
+        operationType: 'static_value',
+        isBucketed: false,
+        scale: 'ratio',
+        params: { value: '23' },
+        references: [],
+      });
+    });
+
+    it('should prioritize passed arguments over previousColumn', () => {
+      expect(
+        staticValueOperation.buildColumn(
+          {
+            indexPattern: createMockedIndexPattern(),
+            layer: { columns: {}, columnOrder: [], indexPatternId: '' },
+            previousColumn: {
+              label: 'Static value',
+              dataType: 'number',
+              operationType: 'static_value',
+              isBucketed: false,
+              scale: 'ratio',
+              params: { value: '23' },
+              references: [],
+            },
+          },
+          { value: '53' }
+        )
+      ).toEqual({
+        label: 'Static value: 53',
+        dataType: 'number',
+        operationType: 'static_value',
+        isBucketed: false,
+        scale: 'ratio',
+        params: { value: '53' },
+        references: [],
+      });
+    });
+  });
+
+  describe('paramEditor', () => {
+    const ParamEditor = staticValueOperation.paramEditor!;
+    it('should render current static_value', () => {
+      const updateLayerSpy = jest.fn();
+      const instance = shallow(
+        <ParamEditor
+          {...defaultProps}
+          layer={layer}
+          updateLayer={updateLayerSpy}
+          columnId="col2"
+          currentColumn={layer.columns.col2 as StaticValueIndexPatternColumn}
+        />
+      );
+
+      const input = instance.find('[data-test-subj="lns-indexPattern-static_value-input"]');
+
+      expect(input.prop('value')).toEqual('23');
+    });
+
+    it('should update state on change', async () => {
+      const updateLayerSpy = jest.fn();
+      const instance = mount(
+        <ParamEditor
+          {...defaultProps}
+          layer={layer}
+          updateLayer={updateLayerSpy}
+          columnId="col2"
+          currentColumn={layer.columns.col2 as StaticValueIndexPatternColumn}
+        />
+      );
+
+      const input = instance
+        .find('[data-test-subj="lns-indexPattern-static_value-input"]')
+        .find(EuiFieldNumber);
+
+      await act(async () => {
+        input.prop('onChange')!({
+          currentTarget: { value: '27' },
+        } as React.ChangeEvent<HTMLInputElement>);
+      });
+
+      instance.update();
+
+      expect(updateLayerSpy).toHaveBeenCalledWith({
+        ...layer,
+        columns: {
+          ...layer.columns,
+          col2: {
+            ...layer.columns.col2,
+            params: {
+              value: '27',
+            },
+            label: 'Static value: 27',
+          },
+        },
+      });
+    });
+
+    it('should not update on invalid input, but show invalid value locally', async () => {
+      const updateLayerSpy = jest.fn();
+      const instance = mount(
+        <ParamEditor
+          {...defaultProps}
+          layer={layer}
+          updateLayer={updateLayerSpy}
+          columnId="col2"
+          currentColumn={layer.columns.col2 as StaticValueIndexPatternColumn}
+        />
+      );
+
+      const input = instance
+        .find('[data-test-subj="lns-indexPattern-static_value-input"]')
+        .find(EuiFieldNumber);
+
+      await act(async () => {
+        input.prop('onChange')!({
+          currentTarget: { value: '' },
+        } as React.ChangeEvent<HTMLInputElement>);
+      });
+
+      instance.update();
+
+      expect(updateLayerSpy).not.toHaveBeenCalled();
+      expect(
+        instance
+          .find('[data-test-subj="lns-indexPattern-static_value-input"]')
+          .find(EuiFieldNumber)
+          .prop('value')
+      ).toEqual('');
+    });
+  });
+});

--- a/x-pack/plugins/lens/public/shared_components/debounced_value.ts
+++ b/x-pack/plugins/lens/public/shared_components/debounced_value.ts
@@ -11,6 +11,10 @@ import { debounce } from 'lodash';
 /**
  * Debounces value changes and updates inputValue on root state changes if no debounced changes
  * are in flight because the user is currently modifying the value.
+ *
+ * * allowFalsyValue: update upstream with all falsy values but null or undefined
+ *
+ * When testing this function mock the "debounce" function in lodash (see this module test for an example)
  */
 
 export const useDebouncedValue = <T>(

--- a/x-pack/plugins/lens/public/xy_visualization/threshold_helpers.tsx
+++ b/x-pack/plugins/lens/public/xy_visualization/threshold_helpers.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { layerTypes } from '../../common';
+import { XYLayerConfig } from '../../common/expressions';
+import { DatasourcePublicAPI, FramePublicAPI } from '../types';
+import { isPercentageSeries } from './state_helpers';
+import { XYState } from './types';
+import { checkScaleOperation } from './visualization_helpers';
+
+export interface ThresholdBase {
+  label: 'x' | 'yRight' | 'yLeft';
+}
+
+export function getGroupsToShow<T extends ThresholdBase>(
+  thresholdLayers: T[],
+  state: XYState | undefined,
+  datasourceLayers: Record<string, DatasourcePublicAPI>
+): T[] {
+  if (!state) {
+    return [];
+  }
+  const dataLayers = state.layers.filter(
+    ({ layerType = layerTypes.DATA }) => layerType === layerTypes.DATA
+  );
+  const groupsAvailable = getGroupsAvailableInData(dataLayers, datasourceLayers);
+  return thresholdLayers.filter(({ label }: T) => groupsAvailable[label]);
+}
+
+export function getGroupsAvailableInData(
+  dataLayers: XYState['layers'],
+  datasourceLayers: Record<string, DatasourcePublicAPI>
+) {
+  const hasNumberHistogram = dataLayers.some(
+    checkScaleOperation('interval', 'number', datasourceLayers)
+  );
+  return dataLayers.reduce(
+    (memo, dataLayer) => {
+      if (!memo.x && hasNumberHistogram) {
+        memo.x = Boolean(dataLayer.xAccessor);
+      }
+      if (!memo.yLeft) {
+        const leftConfigs = dataLayer.yConfig?.filter(({ axisMode }) => axisMode !== 'right');
+        const hasMoreConfigsThanAccessor =
+          dataLayer.accessors.length > (dataLayer.yConfig?.length ?? 0);
+
+        memo.yLeft = Boolean(
+          dataLayer.accessors.length &&
+            (leftConfigs == null || leftConfigs.length || hasMoreConfigsThanAccessor)
+        );
+      }
+      if (!memo.yRight) {
+        memo.yRight = Boolean(
+          dataLayer.accessors.length &&
+            dataLayer.yConfig?.some(({ axisMode }) => axisMode === 'right')
+        );
+      }
+      return memo;
+    },
+    { x: false, yLeft: false, yRight: false }
+  );
+}
+
+export function getStaticValue(
+  dataLayers: XYState['layers'],
+  groupId: 'x' | 'yLeft' | 'yRight',
+  { activeData }: Pick<FramePublicAPI, 'activeData'>,
+  layerHasNumberHistogram: (layer: XYLayerConfig) => boolean
+) {
+  const fallbackValue = 100;
+  if (!activeData) {
+    return fallbackValue;
+  }
+
+  // filter and organize data dimensions into threshold groups
+  // now pick the columnId in the active data
+  return (
+    computeStaticValueForGroup(
+      dataLayers,
+      activeData,
+      getAccessorCriteriaForGroup(groupId),
+      (layer) => groupId === 'x' && !layerHasNumberHistogram(layer)
+    ) || fallbackValue
+  );
+}
+
+function getAccessorCriteriaForGroup(
+  groupId: 'x' | 'yLeft' | 'yRight'
+): (layer: XYLayerConfig) => string | undefined {
+  switch (groupId) {
+    case 'x':
+      return ({ xAccessor }) => xAccessor;
+    case 'yLeft':
+      return ({ accessors, yConfig }) => {
+        if (yConfig == null) {
+          return accessors[0];
+        }
+        return yConfig.find(({ axisMode }) => axisMode == null || axisMode === 'left')?.forAccessor;
+      };
+    case 'yRight':
+      return ({ yConfig }) => {
+        return yConfig?.find(({ axisMode }) => axisMode === 'right')?.forAccessor;
+      };
+  }
+}
+
+function computeStaticValueForGroup(
+  dataLayers: XYState['layers'],
+  activeData: NonNullable<FramePublicAPI['activeData']>,
+  getColumnIdForGroup: (layer: XYLayerConfig) => string | undefined,
+  dropForDateHistogram: (layer: XYLayerConfig) => boolean
+) {
+  const dataLayer = dataLayers.find(getColumnIdForGroup);
+
+  if (dataLayer) {
+    if (isPercentageSeries(dataLayer?.seriesType)) {
+      return 0.75;
+    }
+    if (dropForDateHistogram(dataLayer)) {
+      return;
+    }
+    const columnId = getColumnIdForGroup(dataLayer);
+    const tableId = Object.keys(activeData).find((key) =>
+      activeData[key].columns.some(({ id }) => id === columnId)
+    );
+    if (columnId && tableId) {
+      const columnMax = activeData[tableId].rows.reduce(
+        (max, row) => Math.max(row[columnId], max),
+        -Infinity
+      );
+      return Number(((columnMax * 3) / 4).toFixed(2));
+    }
+  }
+}

--- a/x-pack/plugins/lens/public/xy_visualization/visualization.test.ts
+++ b/x-pack/plugins/lens/public/xy_visualization/visualization.test.ts
@@ -690,7 +690,32 @@ describe('xy_visualization', () => {
         expect(bottom.groupId).toBe('xThreshold');
       });
 
-      it.todo('should ignore terms operation for xAccessor');
+      it('should ignore terms operation for xAccessor', () => {
+        const state = getStateWithBaseThreshold();
+        state.layers[0].xAccessor = 'b';
+        state.layers[0].accessors = [];
+        state.layers[1].yConfig![0].axisMode = 'bottom';
+        // set the xAccessor as top values
+        frame.datasourceLayers.threshold.getOperationForColumnId = jest.fn((accessor) => {
+          if (accessor === 'b') {
+            return {
+              dataType: 'string',
+              isBucketed: true,
+              scale: 'ordinal',
+              label: 'top values',
+            };
+          }
+          return null;
+        });
+
+        const options = xyVisualization.getConfiguration({
+          state,
+          frame,
+          layerId: 'threshold',
+        }).groups;
+
+        expect(options).toHaveLength(0);
+      });
     });
 
     describe('color assignment', () => {

--- a/x-pack/plugins/lens/public/xy_visualization/visualization_helpers.tsx
+++ b/x-pack/plugins/lens/public/xy_visualization/visualization_helpers.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { DatasourcePublicAPI } from '../types';
+import { XYState } from './types';
+import { isHorizontalChart } from './state_helpers';
+import { XYLayerConfig } from '../../common/expressions';
+
+export function getAxisName(
+  axis: 'x' | 'y' | 'yLeft' | 'yRight',
+  { isHorizontal }: { isHorizontal: boolean }
+) {
+  const vertical = i18n.translate('xpack.lens.xyChart.verticalAxisLabel', {
+    defaultMessage: 'Vertical axis',
+  });
+  const horizontal = i18n.translate('xpack.lens.xyChart.horizontalAxisLabel', {
+    defaultMessage: 'Horizontal axis',
+  });
+  if (axis === 'x') {
+    return isHorizontal ? vertical : horizontal;
+  }
+  if (axis === 'y') {
+    return isHorizontal ? horizontal : vertical;
+  }
+  const verticalLeft = i18n.translate('xpack.lens.xyChart.verticalLeftAxisLabel', {
+    defaultMessage: 'Vertical left axis',
+  });
+  const verticalRight = i18n.translate('xpack.lens.xyChart.verticalRightAxisLabel', {
+    defaultMessage: 'Vertical right axis',
+  });
+  const horizontalTop = i18n.translate('xpack.lens.xyChart.horizontalLeftAxisLabel', {
+    defaultMessage: 'Horizontal top axis',
+  });
+  const horizontalBottom = i18n.translate('xpack.lens.xyChart.horizontalRightAxisLabel', {
+    defaultMessage: 'Horizontal bottom axis',
+  });
+  if (axis === 'yLeft') {
+    return isHorizontal ? horizontalTop : verticalLeft;
+  }
+  return isHorizontal ? horizontalBottom : verticalRight;
+}
+
+// min requirement for the bug:
+// * 2 or more layers
+// * at least one with date histogram
+// * at least one with interval function
+export function checkXAccessorCompatibility(
+  state: XYState,
+  datasourceLayers: Record<string, DatasourcePublicAPI>
+) {
+  const errors = [];
+  const hasDateHistogramSet = state.layers.some(
+    checkScaleOperation('interval', 'date', datasourceLayers)
+  );
+  const hasNumberHistogram = state.layers.some(
+    checkScaleOperation('interval', 'number', datasourceLayers)
+  );
+  const hasOrdinalAxis = state.layers.some(
+    checkScaleOperation('ordinal', undefined, datasourceLayers)
+  );
+  if (state.layers.length > 1 && hasDateHistogramSet && hasNumberHistogram) {
+    errors.push({
+      shortMessage: i18n.translate('xpack.lens.xyVisualization.dataTypeFailureXShort', {
+        defaultMessage: `Wrong data type for {axis}.`,
+        values: {
+          axis: getAxisName('x', { isHorizontal: isHorizontalChart(state.layers) }),
+        },
+      }),
+      longMessage: i18n.translate('xpack.lens.xyVisualization.dataTypeFailureXLong', {
+        defaultMessage: `Data type mismatch for the {axis}. Cannot mix date and number interval types.`,
+        values: {
+          axis: getAxisName('x', { isHorizontal: isHorizontalChart(state.layers) }),
+        },
+      }),
+    });
+  }
+  if (state.layers.length > 1 && (hasDateHistogramSet || hasNumberHistogram) && hasOrdinalAxis) {
+    errors.push({
+      shortMessage: i18n.translate('xpack.lens.xyVisualization.dataTypeFailureXShort', {
+        defaultMessage: `Wrong data type for {axis}.`,
+        values: {
+          axis: getAxisName('x', { isHorizontal: isHorizontalChart(state.layers) }),
+        },
+      }),
+      longMessage: i18n.translate('xpack.lens.xyVisualization.dataTypeFailureXOrdinalLong', {
+        defaultMessage: `Data type mismatch for the {axis}, use a different function.`,
+        values: {
+          axis: getAxisName('x', { isHorizontal: isHorizontalChart(state.layers) }),
+        },
+      }),
+    });
+  }
+  return errors;
+}
+
+export function checkScaleOperation(
+  scaleType: 'ordinal' | 'interval' | 'ratio',
+  dataType: 'date' | 'number' | 'string' | undefined,
+  datasourceLayers: Record<string, DatasourcePublicAPI>
+) {
+  return (layer: XYLayerConfig) => {
+    const datasourceAPI = datasourceLayers[layer.layerId];
+    if (!layer.xAccessor) {
+      return false;
+    }
+    const operation = datasourceAPI?.getOperationForColumnId(layer.xAccessor);
+    return Boolean(
+      operation && (!dataType || operation.dataType === dataType) && operation.scale === scaleType
+    );
+  };
+}

--- a/x-pack/test/functional/apps/lens/index.ts
+++ b/x-pack/test/functional/apps/lens/index.ts
@@ -43,6 +43,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       loadTestFile(require.resolve('./lens_tagging'));
       loadTestFile(require.resolve('./formula'));
       loadTestFile(require.resolve('./heatmap'));
+      loadTestFile(require.resolve('./thresholds'));
 
       // has to be last one in the suite because it overrides saved objects
       loadTestFile(require.resolve('./rollup'));

--- a/x-pack/test/functional/apps/lens/thresholds.ts
+++ b/x-pack/test/functional/apps/lens/thresholds.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
+  const PageObjects = getPageObjects(['visualize', 'lens', 'common', 'header']);
+  const find = getService('find');
+  const retry = getService('retry');
+  //   const listingTable = getService('listingTable');
+  const testSubjects = getService('testSubjects');
+  //   const elasticChart = getService('elasticChart');
+  //   const filterBar = getService('filterBar');
+
+  describe('lens thresholds tests', () => {
+    it('should show a disabled threshold layer button if no data dimension is defined', async () => {
+      await PageObjects.visualize.navigateToNewVisualization();
+      await PageObjects.visualize.clickVisType('lens');
+
+      await testSubjects.click('lnsLayerAddButton');
+      await retry.waitFor('wait for layer popup to appear', async () =>
+        testSubjects.exists(`lnsLayerAddButton-threshold`)
+      );
+      expect(
+        await (await testSubjects.find(`lnsLayerAddButton-threshold`)).getAttribute('disabled')
+      ).to.be('true');
+    });
+
+    it('should add a threshold layer with a static value in it', async () => {
+      await PageObjects.visualize.navigateToNewVisualization();
+      await PageObjects.visualize.clickVisType('lens');
+      await PageObjects.lens.goToTimeRange();
+
+      await PageObjects.lens.configureDimension({
+        dimension: 'lnsXY_xDimensionPanel > lns-empty-dimension',
+        operation: 'date_histogram',
+        field: '@timestamp',
+      });
+
+      await PageObjects.lens.configureDimension({
+        dimension: 'lnsXY_yDimensionPanel > lns-empty-dimension',
+        operation: 'average',
+        field: 'bytes',
+      });
+
+      await PageObjects.lens.createLayer('threshold');
+
+      expect((await find.allByCssSelector(`[data-test-subj^="lns-layerPanel-"]`)).length).to.eql(2);
+      expect(
+        await (
+          await testSubjects.find('lnsXY_yThresholdLeftPanel > lns-dimensionTrigger')
+        ).getVisibleText()
+      ).to.eql('Static value: 100');
+    });
+
+    it('should create a dynamic threshold when dragging a field to a threshold dimension group', async () => {
+      await PageObjects.lens.dragFieldToDimensionTrigger(
+        'bytes',
+        'lnsXY_yThresholdLeftPanel > lns-empty-dimension'
+      );
+
+      expect(await PageObjects.lens.getDimensionTriggersTexts('lnsXY_yThresholdLeftPanel')).to.eql([
+        'Static value: 100',
+        'Median of bytes',
+      ]);
+    });
+  });
+}

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -645,8 +645,21 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
     /**
      * Adds a new layer to the chart, fails if the chart does not support new layers
      */
-    async createLayer() {
+    async createLayer(layerType: string = 'data') {
       await testSubjects.click('lnsLayerAddButton');
+      const layerCount = (await find.allByCssSelector(`[data-test-subj^="lns-layerPanel-"]`))
+        .length;
+
+      await retry.waitFor('check for layer type support', async () => {
+        const fasterChecks = await Promise.all([
+          (await find.allByCssSelector(`[data-test-subj^="lns-layerPanel-"]`)).length > layerCount,
+          testSubjects.exists(`lnsLayerAddButton-${layerType}`),
+        ]);
+        return fasterChecks.filter(Boolean).length > 0;
+      });
+      if (await testSubjects.exists(`lnsLayerAddButton-${layerType}`)) {
+        await testSubjects.click(`lnsLayerAddButton-${layerType}`);
+      }
     },
 
     /**


### PR DESCRIPTION
## Summary

Built on top of https://github.com/elastic/kibana/pull/108342

* Unit tests
	* [x] UI components
	* [x] Static value operation
	* [x] XY Visualization
		* [x] `getConfiguration` for different type of combinations
		* [x] `setDimension` for different type of combinations
* Functional tests
	* [x] Add one threshold layer on XY chart
	* [x] Add one threshold layer on XY chart with multiple dimensions
	* [x] Drag and drop fields on threshold layer

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
