### PR TITLE
use interfaces to get project routing overrides

### DIFF
--- a/x-pack/platform/plugins/shared/maps/public/classes/layers/layer.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/layers/layer.tsx
@@ -22,6 +22,7 @@ import React from 'react';
 import { EuiIcon } from '@elastic/eui';
 import { v4 as uuidv4 } from 'uuid';
 import type { FeatureCollection } from 'geojson';
+import type { ProjectRoutingOverrides } from '@kbn/presentation-publishing';
 import { DataRequest } from '../util/data_request';
 import { hasIncompleteResults } from '../util/tile_meta_feature_utils';
 import type { LAYER_TYPE } from '../../../common/constants';
@@ -114,6 +115,10 @@ export interface ILayer {
    * ILayer.getIndexPatternIds returns data view ids used to populate layer data.
    */
   getIndexPatternIds(): string[];
+  /*
+   * ILayer.getProjectRoutingOverrides returns project routing overrides used to populate layer data.
+   */
+  getProjectRoutingOverrides?: () => Promise<ProjectRoutingOverrides>;
   /*
    * ILayer.getQueryableIndexPatternIds returns ILayer.getIndexPatternIds or a subset of ILayer.getIndexPatternIds.
    * Data view ids are excluded when the global query is not applied to layer data.

--- a/x-pack/platform/plugins/shared/maps/public/classes/sources/es_source/types.ts
+++ b/x-pack/platform/plugins/shared/maps/public/classes/sources/es_source/types.ts
@@ -54,6 +54,8 @@ export interface IESSource extends IVectorSource {
 
   getGeoFieldName(): string | undefined;
 
+  getProjectRouting?: () => string | undefined;
+
   loadStylePropsMeta({
     layerName,
     style,

--- a/x-pack/platform/plugins/shared/maps/public/classes/sources/esql_source/esql_source.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/sources/esql_source/esql_source.tsx
@@ -17,6 +17,7 @@ import {
   getESQLQueryColumnsRaw,
   getIndexPatternFromESQLQuery,
   getLimitFromESQLQuery,
+  getProjectRoutingFromEsqlQuery,
   getStartEndParams,
   hasStartEndParams,
 } from '@kbn/esql-utils';
@@ -73,7 +74,10 @@ export class ESQLSource
   extends AbstractVectorSource
   implements
     IVectorSource,
-    Pick<IESSource, 'getIndexPattern' | 'getIndexPatternId' | 'getGeoFieldName'>
+    Pick<
+      IESSource,
+      'getIndexPattern' | 'getIndexPatternId' | 'getGeoFieldName' | 'getProjectRouting'
+    >
 {
   readonly _descriptor: NormalizedESQLSourceDescriptor;
   private _dataViewId: string | undefined;
@@ -392,6 +396,10 @@ export class ESQLSource
 
   getESQL() {
     return this._descriptor.esql;
+  }
+
+  getProjectRouting() {
+    return getProjectRoutingFromEsqlQuery(this.getESQL());
   }
 
   private _getDataViewFields = async () => {

--- a/x-pack/platform/plugins/shared/maps/public/react_embeddable/map_react_embeddable.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/react_embeddable/map_react_embeddable.tsx
@@ -44,6 +44,7 @@ import { initializeFetch } from './initialize_fetch';
 import { initializeEditApi } from './initialize_edit_api';
 import { isMapRendererApi } from './map_renderer/types';
 import type { MapByReferenceState, MapEmbeddableState } from '../../common';
+import { initializeProjectRoutingManager } from './project_routing_manager';
 
 export function getControlledBy(id: string) {
   return `mapEmbeddablePanel${id}`;
@@ -91,6 +92,7 @@ export const mapEmbeddableFactory: EmbeddableFactory<MapEmbeddableState, MapApi>
       savedMap,
       uuid,
     });
+    const projectRoutingManager = await initializeProjectRoutingManager(savedMap);
 
     function getLatestState() {
       return {
@@ -182,6 +184,7 @@ export const mapEmbeddableFactory: EmbeddableFactory<MapEmbeddableState, MapApi>
         serializeByValue
       ),
       ...initializeDataViews(savedMap.getStore()),
+      ...projectRoutingManager.api,
       serializeState,
       supportedTriggers: () => {
         return [APPLY_FILTER_TRIGGER, VALUE_CLICK_TRIGGER];

--- a/x-pack/platform/plugins/shared/maps/public/react_embeddable/project_routing_manager.ts
+++ b/x-pack/platform/plugins/shared/maps/public/react_embeddable/project_routing_manager.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { asyncForEach } from '@kbn/std';
+import type { ProjectRoutingOverrides } from '@kbn/presentation-publishing';
+import { BehaviorSubject } from 'rxjs';
+import type { ILayer } from '../classes/layers/layer';
+import type { SavedMap } from '../routes';
+import { getLayerList } from '../selectors/map_selectors';
+
+async function getProjectRoutingOverrides(layers: ILayer[]) {
+  const overrides: ProjectRoutingOverrides = [];
+  await asyncForEach(layers, async (layer) => {
+    const layerOverrides = await layer.getProjectRoutingOverrides?.();
+    if (layerOverrides) {
+      overrides.push(...layerOverrides);
+    }
+  });
+  return overrides.length > 0 ? overrides : undefined;
+}
+
+export async function initializeProjectRoutingManager(savedMap: SavedMap) {
+  const store = savedMap.getStore();
+
+  // TODO update projectRoutingOverrides$ on layer changes when inline editing is implemented
+  const projectRoutingOverrides$ = new BehaviorSubject<ProjectRoutingOverrides>(
+    await getProjectRoutingOverrides(getLayerList(store.getState()))
+  );
+
+  return {
+    api: {
+      projectRoutingOverrides$,
+    },
+  };
+}


### PR DESCRIPTION
Use interfaces to extract project routing from layers instead of reading from state.