### PR TITLE
project routing clean up

### DIFF
--- a/src/platform/packages/shared/kbn-es-query/src/expressions/types.ts
+++ b/src/platform/packages/shared/kbn-es-query/src/expressions/types.ts
@@ -8,7 +8,6 @@
  */
 import type { ESQLControlVariable } from '@kbn/esql-types';
 import type { Filter, Query, TimeRange } from '../filters';
-import type { ProjectRouting } from '../project_routing';
 
 export interface ExecutionContextSearch {
   now?: number;
@@ -17,5 +16,4 @@ export interface ExecutionContextSearch {
   timeRange?: TimeRange;
   disableWarningToasts?: boolean;
   esqlVariables?: ESQLControlVariable[];
-  projectRouting?: ProjectRouting;
 }

--- a/src/platform/packages/shared/kbn-search-types/src/types.ts
+++ b/src/platform/packages/shared/kbn-search-types/src/types.ts
@@ -13,6 +13,7 @@ import type { TransportRequestOptions } from '@elastic/elasticsearch';
 import type { KibanaExecutionContext } from '@kbn/core/public';
 import type { AbstractDataView } from '@kbn/data-views-plugin/common';
 import type { Observable } from 'rxjs';
+import type { ProjectRouting } from '@kbn/es-query';
 import type { IEsSearchRequest, IEsSearchResponse } from './es_search_types';
 import type { IKibanaSearchRequest, IKibanaSearchResponse } from './kibana_search_types';
 
@@ -124,6 +125,11 @@ export interface ISearchOptions {
    * A hash of the request params. This is attached automatically by the search interceptor. It is used to link this request with a search session.
    */
   requestHash?: string;
+
+  /**
+   * Project routing configuration for cross-project search (CPS).
+   */
+  projectRouting?: ProjectRouting;
 }
 
 /**
@@ -141,4 +147,5 @@ export type ISearchOptionsSerializable = Pick<
   | 'retrieveResults'
   | 'executionContext'
   | 'stream'
+  | 'projectRouting'
 >;

--- a/src/platform/plugins/private/vis_types/vega/public/data_model/search_api.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/data_model/search_api.ts
@@ -16,7 +16,6 @@ import { getSearchParamsFromRequest } from '@kbn/data-plugin/public';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import { search as dataPluginSearch } from '@kbn/data-plugin/public';
 import type { RequestResponder } from '@kbn/inspector-plugin/public';
-import type { ProjectRouting } from '@kbn/es-query';
 import type { VegaInspectorAdapters } from '../vega_inspector';
 
 /** @internal **/
@@ -56,8 +55,7 @@ export class SearchAPI {
     private readonly abortSignal?: AbortSignal,
     public readonly inspectorAdapters?: VegaInspectorAdapters,
     private readonly searchSessionId?: string,
-    private readonly executionContext?: KibanaExecutionContext,
-    private readonly projectRouting?: ProjectRouting
+    private readonly executionContext?: KibanaExecutionContext
   ) {}
 
   search(searchRequests: SearchRequest[]) {
@@ -86,11 +84,6 @@ export class SearchAPI {
             }
           }),
           switchMap((params) => {
-            if (this.projectRouting) {
-              // @ts-ignore it will not throw ts error once ES client supports it
-              params.body.project_routing = this.projectRouting;
-            }
-
             return search
               .search(
                 { params },

--- a/src/platform/plugins/shared/data/common/search/expressions/esaggs/request_handler.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/esaggs/request_handler.ts
@@ -13,7 +13,7 @@ import { defer } from 'rxjs';
 import { map, switchMap } from 'rxjs';
 import type { Adapters } from '@kbn/inspector-plugin/common';
 import type { DataView } from '@kbn/data-views-plugin/common';
-import type { Filter, ProjectRouting, TimeRange } from '@kbn/es-query';
+import type { Filter, TimeRange } from '@kbn/es-query';
 
 import type { Query } from '../../..';
 import { calculateBounds } from '../../..';
@@ -38,7 +38,6 @@ export interface RequestHandlerParams {
   executionContext?: KibanaExecutionContext;
   title?: string;
   description?: string;
-  projectRouting?: ProjectRouting;
 }
 
 export const handleRequest = ({
@@ -57,7 +56,6 @@ export const handleRequest = ({
   executionContext,
   title,
   description,
-  projectRouting,
 }: RequestHandlerParams) => {
   return defer(async () => {
     const forceNow = getNow?.();
@@ -108,10 +106,6 @@ export const handleRequest = ({
 
     requestSearchSource.setField('filter', filters);
     requestSearchSource.setField('query', query);
-
-    if (projectRouting) {
-      requestSearchSource.setField('projectRouting', projectRouting);
-    }
 
     return { allTimeFields, forceNow, requestSearchSource };
   }).pipe(

--- a/src/platform/plugins/shared/data/common/search/expressions/esql.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/esql.ts
@@ -239,11 +239,6 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
             ];
 
             params.filter = buildEsQuery(undefined, input.query || [], filters, esQueryConfigs);
-
-            if (input.projectRouting) {
-              // Don't sanitize here - search_interceptor needs the raw value to distinguish explicit 'ALL' from missing value
-              params.project_routing = input.projectRouting;
-            }
           }
 
           let startTime = Date.now();

--- a/src/platform/plugins/shared/data/common/search/expressions/kibana.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/kibana.ts
@@ -51,7 +51,6 @@ export const kibana: ExpressionFunctionKibana = {
       filters: [...(searchContext.filters || []), ...((input || {}).filters || [])],
       timeRange: searchContext.timeRange || (input ? input.timeRange : undefined),
       esqlVariables: searchContext.esqlVariables || (input ? input.esqlVariables : undefined),
-      projectRouting: searchContext.projectRouting || (input ? input.projectRouting : undefined),
     };
 
     return output;

--- a/src/platform/plugins/shared/data/common/search/search_source/search_source.ts
+++ b/src/platform/plugins/shared/data/common/search/search_source/search_source.ts
@@ -682,8 +682,6 @@ export class SearchSource {
         return addToBody(key, sort);
       case 'pit':
         return addToRoot(key, val);
-      case 'projectRouting':
-        return addToBody('project_routing', val);
       case 'aggs':
         if ((val as unknown) instanceof AggConfigs) {
           return addToBody('aggs', val.toDsl());

--- a/src/platform/plugins/shared/data/public/search/search_interceptor/project_routing.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/project_routing.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ICPSManager } from '@kbn/cps-utils';
+import { ProjectRoutingAccess } from '@kbn/cps-utils';
+import { sanitizeProjectRoutingForES } from '@kbn/es-query';
+import type { ISearchOptions } from '@kbn/search-types';
+
+export function getProjectRouting(cpsManager?: ICPSManager): ISearchOptions['projectRouting'] {
+  return cpsManager && cpsManager.getProjectPickerAccess() !== ProjectRoutingAccess.DISABLED
+    ? sanitizeProjectRoutingForES(cpsManager.getProjectRouting())
+    : undefined;
+}

--- a/src/platform/plugins/shared/data/server/search/routes/search.ts
+++ b/src/platform/plugins/shared/data/server/search/routes/search.ts
@@ -55,6 +55,7 @@ export function registerSearchRoute(
                 retrieveResults: schema.maybe(schema.boolean()),
                 stream: schema.maybe(schema.boolean()),
                 requestHash: schema.maybe(schema.string()),
+                projectRouting: schema.maybe(schema.string()),
               },
               { unknowns: 'allow' }
             ),
@@ -70,6 +71,7 @@ export function registerSearchRoute(
           retrieveResults,
           stream,
           requestHash,
+          projectRouting,
           ...searchRequest
         } = request.body;
         const { strategy, id } = request.params;
@@ -104,6 +106,7 @@ export function registerSearchRoute(
                   retrieveResults,
                   stream,
                   requestHash,
+                  projectRouting,
                 }
               )
               .pipe(first())

--- a/src/platform/plugins/shared/data/server/search/strategies/common/async_utils.ts
+++ b/src/platform/plugins/shared/data/server/search/strategies/common/async_utils.ts
@@ -29,7 +29,7 @@ export function getCommonDefaultAsyncSubmitParams(
 ): Pick<
   AsyncSearchSubmitRequest,
   'keep_alive' | 'wait_for_completion_timeout' | 'keep_on_completion'
-> {
+> & { project_routing?: string } {
   const useSearchSessions =
     config.sessions.enabled && !!options.sessionId && !overrides?.disableSearchSessions;
   const keepAlive =
@@ -44,6 +44,8 @@ export function getCommonDefaultAsyncSubmitParams(
     keep_on_completion: useSearchSessions,
     // The initial keepalive is as defined in defaultExpiration if search sessions are used or 1m otherwise.
     keep_alive: keepAlive,
+    // Pass project routing for CPS if available
+    ...(options.projectRouting !== undefined && { project_routing: options.projectRouting }),
   };
 }
 

--- a/src/platform/plugins/shared/data/server/search/strategies/es_search/es_search_strategy.ts
+++ b/src/platform/plugins/shared/data/server/search/strategies/es_search/es_search_strategy.ts
@@ -70,6 +70,7 @@ export const esSearchStrategyProvider = (
           ...defaults,
           ...getShardTimeout(config),
           ...(terminateAfter ? { terminate_after: terminateAfter } : {}),
+          ...(options.projectRouting !== undefined && { project_routing: options.projectRouting }),
           ...requestParams,
         };
         const { body, meta } = await esClient.asCurrentUser.search(params, {

--- a/src/platform/plugins/shared/data/server/search/strategies/ese_search/request_utils.ts
+++ b/src/platform/plugins/shared/data/server/search/strategies/ese_search/request_utils.ts
@@ -49,7 +49,7 @@ export async function getDefaultAsyncSubmitParams(
     | 'ignore_unavailable'
     | 'track_total_hits'
     | 'keep_on_completion'
-  >
+  > & { project_routing?: string }
 > {
   return {
     // TODO: adjust for partial results


### PR DESCRIPTION
## Summary

Moves project routing handling to a central place. This covers the use cases we discussed (discover, field list, visualize, vega, esql, etc.) 

I removed the handling from search source and the esql/esaggs expression functions, but feel free to keep them if we have a use case for overriding what is selected in the project picker.